### PR TITLE
fix add_addr bug

### DIFF
--- a/scaffold-aptos/src/pages/index.tsx
+++ b/scaffold-aptos/src/pages/index.tsx
@@ -85,14 +85,13 @@ export default function Home() {
 
   function add_addr() {
     const { description, resource_path, addr_type, addr, addr_description, chains } = formInput;
-    let addr_handled = addr.replace('0x', '');
     return {
       type: "entry_function_payload",
       function: DAPP_ADDRESS + "::addr_aggregator::add_addr",
       type_arguments: [],
       arguments: [
         addr_type,
-        addr_handled,
+        addr,
         chains,
         addr_description,
 


### PR DESCRIPTION
0x cannot be removed. The contract addr_info::check_addr_prefix method requires the address to begin with 0x.
https://github.com/NonceGeek/MoveDID/blob/main/did-aptos/sources/addr_aggregator.move#L44
https://github.com/NonceGeek/MoveDID/blob/main/did-aptos/sources/addr_info.move#L88-L91
